### PR TITLE
Touchup sbt plugin

### DIFF
--- a/OrchidCore/src/orchid/resources/wiki/user-manual/getting-started/quickstart.md
+++ b/OrchidCore/src/orchid/resources/wiki/user-manual/getting-started/quickstart.md
@@ -311,7 +311,7 @@ orchidTheme := "BsDoc"
 
 However, for this to work, you will need to make sure the theme and any other features
 your site relies upon are available to the build. Orchid offers a very rich feature set, made available via distinct, dynamically loaded dependencies.
-In order to use these fetures, you'll want to add them as dependies *of the build, not your project*.
+In order to use these features, you'll want to add them as dependies *of the build, not your project*.
 
 The easiest way to do this is just include these dependencies in your `project/plugins.sbt` file.
 [Below](#rich-projectpluginssbt-example) is a very rich example `project/plugins.sbt` file. You can use any of the main Orchid features

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ generated based on your current Orchid plugins and configurations.
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/JavaEden/OrchidStarter)
 
 To run Orchid locally, the only system dependency necessary is a valid Java 8 JDK. Orchid can be integrated with any new
- or existing Gradle or Maven project or bootstrapped manually in any JVM-based scriptlet (such as 
+ or existing Gradle, Maven, or sbt project, or bootstrapped manually in any JVM-based scriptlet (such as 
 [kscript](https://github.com/holgerbrandl/kscript)). To get started, pick a Bundle (OrchidAll or OrchidBlog) or manually 
 choose your desired Orchid plugins. You may pick a bundle to start with and add any number of plugins afterward, both 
 official and unofficial.
@@ -72,6 +72,7 @@ Orchid can also be integrated into existing projects. The following build tools 
 - [Gradle](https://orchid.netlify.com/wiki/user-manual/getting-started/quickstart#gradle)
 - [Maven](https://orchid.netlify.com/wiki/user-manual/getting-started/quickstart#maven)
 - [KScript](https://orchid.netlify.com/wiki/user-manual/getting-started/quickstart#kscript)
+- [sbt](https://orchid.netlify.com/wiki/user-manual/getting-started/quickstart#sbt)
 
 ## User Manual
 

--- a/buildSrc/orchidSbtPlugin/src/main/scala/com/eden/orchid/sbt/SbtOrchidPlugin.scala
+++ b/buildSrc/orchidSbtPlugin/src/main/scala/com/eden/orchid/sbt/SbtOrchidPlugin.scala
@@ -1,4 +1,4 @@
-package com.mchange.sc.v1.sbtorchid
+package com.eden.orchid.sbt
 
 import sbt._
 import sbt.Keys._


### PR DESCRIPTION
Moves the sbt plugin to a sister package of other orchid build-tool plugin, fixes a misspelling and integrates sbt support into README.md