### PR TITLE
Manually squash and rebase commits from PR #396, making other necessary changes

### DIFF
--- a/OrchidCore/build.gradle.kts
+++ b/OrchidCore/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     // Dynamic Component Registration
     api("javax.inject:javax.inject:1")
     api("com.google.inject:guice:5.0.1")
-    api("io.github.classgraph:classgraph:4.8.47")
+    api("io.github.classgraph:classgraph:4.8.102")
 
     // core utilities
     api("com.squareup.okhttp3:okhttp:4.7.2")

--- a/OrchidCore/src/main/java/com/eden/orchid/api/server/OrchidView.java
+++ b/OrchidCore/src/main/java/com/eden/orchid/api/server/OrchidView.java
@@ -18,6 +18,7 @@ import com.eden.orchid.api.theme.pages.OrchidPage;
 import com.eden.orchid.api.theme.pages.OrchidReference;
 import kotlin.Unit;
 import kotlin.collections.CollectionsKt;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.inject.Provider;
@@ -92,7 +93,7 @@ public final class OrchidView extends OrchidPage {
     }
 
     @Override
-    public String getLayoutBase() {
+    public @NotNull String getLayoutBase() {
         return "server/" + super.getLayoutBase();
     }
 

--- a/OrchidCore/src/main/java/com/eden/orchid/api/theme/permalinks/DefaultPermalinkStrategy.java
+++ b/OrchidCore/src/main/java/com/eden/orchid/api/theme/permalinks/DefaultPermalinkStrategy.java
@@ -4,6 +4,7 @@ import com.eden.common.util.EdenUtils;
 import com.eden.orchid.api.theme.pages.OrchidPage;
 import com.eden.orchid.utilities.OrchidUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
 import java.util.Arrays;
@@ -28,10 +29,25 @@ public final class DefaultPermalinkStrategy implements PermalinkStrategy {
 
     @Override
     public void applyPermalink(OrchidPage page, String permalink, boolean prettyUrl) {
-        String extension = FilenameUtils.getExtension(permalink);
-        String nameWithoutExtension = FilenameUtils.removeExtension(permalink);
-
-        String[] pieces = OrchidUtils.normalizePath(nameWithoutExtension).split("/");
+        String[] pieces = OrchidUtils.normalizePath(permalink).split("/");
+        String extension = "";
+        if(pieces.length > 0) {
+            int index = pieces.length - 1;
+            String last = pieces[index];
+            boolean startsWithColon = last.startsWith(":");
+            if(startsWithColon) {
+                last = last.substring(1);
+            }
+            extension = FilenameUtils.getExtension(last);
+            if(StringUtils.isNotBlank(extension)) {
+                String nameWithoutExtension = FilenameUtils.removeExtension(last);
+                if(startsWithColon) {
+                    pieces[index] = ":" + nameWithoutExtension;
+                } else {
+                    pieces[index] = nameWithoutExtension;
+                }
+            }
+        }
 
         StringBuffer formattedPath = new StringBuffer();
         StringBuffer formattedFileName = new StringBuffer();

--- a/OrchidCore/src/main/kotlin/com/eden/orchid/api/resources/resourcesource/CommonExternalAliasesResourceSource.kt
+++ b/OrchidCore/src/main/kotlin/com/eden/orchid/api/resources/resourcesource/CommonExternalAliasesResourceSource.kt
@@ -1,0 +1,80 @@
+package com.eden.orchid.api.resources.resourcesource
+
+import com.eden.orchid.api.OrchidContext
+import com.eden.orchid.api.resources.resource.ExternalResource
+import com.eden.orchid.api.resources.resource.OrchidResource
+import com.eden.orchid.api.theme.pages.OrchidReference
+import org.apache.commons.io.FilenameUtils
+
+/**
+ * An OrchidResourceSource that provides resources from an external URL. Those resources can later be set to downloaded
+ * over HTTP, and the response body is used as the content for that resource.
+ */
+class CommonExternalAliasesResourceSource(
+    override val priority: Int,
+    override val scope: OrchidResourceSource.Scope
+) : OrchidResourceSource {
+
+    companion object {
+        val aliases = mapOf(
+            "@jquery.js" to "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js",
+
+            "@bootstrap3.css" to "https://netdna.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css",
+            "@bootstrap3.js" to "https://netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js",
+            "@bootbox.js" to "https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/4.3.0/bootbox.min.js",
+
+            "@fontAwesome4.css" to "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css",
+            "@fontAwesome5.js" to "https://use.fontawesome.com/releases/v5.4.0/js/all.js",
+
+            "@githubForkRibbon.css" to "https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css",
+            "@skel.js" to "https://cdnjs.cloudflare.com/ajax/libs/skel/3.0.1/skel.min.js",
+
+            "@uikit.css" to "https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-rc.16/css/uikit.min.css",
+            "@uikit.js" to "https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-rc.16/js/uikit.min.js",
+            "@uikit-icons.js" to "https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-rc.16/js/uikit-icons.min.js",
+            "@vue.js" to "https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.min.js",
+        )
+    }
+
+    override fun getResourceEntry(context: OrchidContext, fileName: String): OrchidResource? {
+        return if (aliases.containsKey(fileName)) {
+            val actualFilename = aliases[fileName]!!
+            ExternalResource(
+                OrchidReference.fromUrl(context, FilenameUtils.getName(actualFilename), actualFilename)
+            )
+        } else {
+            null
+        }
+    }
+
+    override fun getResourceEntries(
+        context: OrchidContext,
+        dirName: String,
+        fileExtensions: Array<String>?,
+        recursive: Boolean
+    ): List<OrchidResource> {
+        return emptyList()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as CommonExternalAliasesResourceSource
+
+        if (priority != other.priority) return false
+        if (scope != other.scope) return false
+
+        return true
+    }
+
+    private val _hashcode by lazy {
+        var result = priority
+        result = 31 * result + scope.hashCode()
+        result
+    }
+
+    override fun hashCode(): Int {
+        return _hashcode
+    }
+}

--- a/OrchidCore/src/main/kotlin/com/eden/orchid/impl/ImplModule.kt
+++ b/OrchidCore/src/main/kotlin/com/eden/orchid/impl/ImplModule.kt
@@ -51,6 +51,7 @@ import com.eden.orchid.impl.generators.ExternalIndexGenerator
 import com.eden.orchid.impl.generators.HomepageGenerator
 import com.eden.orchid.impl.generators.SitemapGenerator
 import com.eden.orchid.impl.publication.ScriptPublisher
+import com.eden.orchid.impl.resources.resourcesource.LocalCommonExternalAliasesResourceSource
 import com.eden.orchid.impl.resources.resourcesource.LocalExternalResourceSource
 import com.eden.orchid.impl.resources.resourcesource.LocalInlineResourceSource
 import com.eden.orchid.impl.resources.resourcesource.LocalFileResourceSource
@@ -161,6 +162,7 @@ class ImplModule(
             // Resource Sources
             addToSet(
                 OrchidResourceSource::class.java,
+                LocalCommonExternalAliasesResourceSource::class.java,
                 LocalExternalResourceSource::class.java,
                 LocalFileResourceSource::class.java,
                 LocalInlineResourceSource::class.java

--- a/OrchidCore/src/main/kotlin/com/eden/orchid/impl/resources/resourcesource/LocalCommonExternalAliasesResourceSource.kt
+++ b/OrchidCore/src/main/kotlin/com/eden/orchid/impl/resources/resourcesource/LocalCommonExternalAliasesResourceSource.kt
@@ -1,10 +1,10 @@
 package com.eden.orchid.impl.resources.resourcesource
 
-import com.eden.orchid.api.resources.resourcesource.ExternalResourceSource
+import com.eden.orchid.api.resources.resourcesource.CommonExternalAliasesResourceSource
 import com.eden.orchid.api.resources.resourcesource.LocalResourceSource
 import com.eden.orchid.api.resources.resourcesource.OrchidResourceSource
 
-class LocalExternalResourceSource : OrchidResourceSource by ExternalResourceSource(
-    Integer.MAX_VALUE - 1,
+class LocalCommonExternalAliasesResourceSource : OrchidResourceSource by CommonExternalAliasesResourceSource(
+    Integer.MAX_VALUE,
     LocalResourceSource
 )

--- a/OrchidCore/src/main/kotlin/com/eden/orchid/impl/resources/resourcesource/LocalFileResourceSource.kt
+++ b/OrchidCore/src/main/kotlin/com/eden/orchid/impl/resources/resourcesource/LocalFileResourceSource.kt
@@ -11,4 +11,8 @@ class LocalFileResourceSource
 @Inject
 constructor(
     @Named("src") resourcesDir: String
-) : OrchidResourceSource by FileResourceSource(File(resourcesDir).toPath(), Integer.MAX_VALUE - 1, LocalResourceSource)
+) : OrchidResourceSource by FileResourceSource(
+    File(resourcesDir).toPath(),
+    Integer.MAX_VALUE - 2,
+    LocalResourceSource
+)

--- a/OrchidCore/src/main/kotlin/com/eden/orchid/impl/resources/resourcesource/LocalInlineResourceSource.kt
+++ b/OrchidCore/src/main/kotlin/com/eden/orchid/impl/resources/resourcesource/LocalInlineResourceSource.kt
@@ -4,4 +4,7 @@ import com.eden.orchid.api.resources.resourcesource.InlineResourceSource
 import com.eden.orchid.api.resources.resourcesource.LocalResourceSource
 import com.eden.orchid.api.resources.resourcesource.OrchidResourceSource
 
-class LocalInlineResourceSource : OrchidResourceSource by InlineResourceSource(Integer.MAX_VALUE - 2, LocalResourceSource)
+class LocalInlineResourceSource : OrchidResourceSource by InlineResourceSource(
+    Integer.MAX_VALUE - 3,
+    LocalResourceSource
+)

--- a/OrchidTest/src/test/kotlin/com/eden/orchid/impl/themes/assets/TestAssetDownloading.kt
+++ b/OrchidTest/src/test/kotlin/com/eden/orchid/impl/themes/assets/TestAssetDownloading.kt
@@ -191,4 +191,52 @@ class TestAssetDownloading : OrchidIntegrationTest(
             .pageWasNotRendered("/test-downloadable-assets/assets/css/style.css")
             .pageWasNotRendered("/test-downloadable-assets/assets/js/scripts.js")
     }
+
+    @Test
+    @DisplayName("Test asset aliases are rewritten properly")
+    fun test04() {
+        flag("environment", "dev")
+        configObject(
+            "site",
+            """
+            |{
+            |   "theme": "${TestAssetTheme.KEY}"
+            |}
+            """.trimMargin()
+        )
+        configObject(
+            "allPages",
+            """
+            |{
+            |   "components": [
+            |       {"type": "pageContent", "noWrapper": false}
+            |   ],
+            |   "extraCss": [
+            |       "@bootstrap3.css"
+            |   ],
+            |   "extraJs": [
+            |       "@jquery.js",
+            |       "@bootstrap3.js"
+            |   ]
+            |}
+            """.trimMargin()
+        )
+
+        execute()
+            .asExpected()
+            .pageWasRendered("/test/asset/page-one/index.html") {
+                htmlHeadMatches("head link[rel=stylesheet]") {
+                    link(href = "http://orchid.test/TestAssetTheme/1e240/${TestAssetTheme.CSS}", rel = "stylesheet", type = "text/css") { }
+                    link(href = "http://orchid.test/${TestAssetPage.CSS}", rel = "stylesheet", type = "text/css") { }
+                    link(href = "https://netdna.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css", rel = "stylesheet", type = "text/css") { }
+                }
+                htmlBodyMatches {
+                    div("component component-pageContent component-order-0") {}
+                    script(src = "http://orchid.test/TestAssetTheme/1e240/${TestAssetTheme.JS}") { }
+                    script(src = "http://orchid.test/${TestAssetPage.JS}") { }
+                    script(src = "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js") { }
+                    script(src = "https://netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js") { }
+                }
+            }
+    }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    runtime(project(":orchidPlugin"))
+    runtimeOnly(project(":orchidPlugin"))
 
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
     implementation("org.jlleitschuh.gradle:ktlint-gradle:10.0.0")

--- a/docs/src/orchid/resources/wiki/learn/tutorials/how-to-blog.md
+++ b/docs/src/orchid/resources/wiki/learn/tutorials/how-to-blog.md
@@ -41,9 +41,9 @@ dependencies {
     orchidCompile "io.github.javaeden.orchid:OrchidPluginDocs:{{ site.version }}"
 }
 
-// 3. Get dependencies from JCenter
+// 3. Get dependencies from MavenCentral
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // 4. Use the 'FutureImperfect' theme, and set the URL it will have on Github Pages

--- a/docs/src/orchid/resources/wiki/learn/tutorials/how-to-document-kotlin.md
+++ b/docs/src/orchid/resources/wiki/learn/tutorials/how-to-document-kotlin.md
@@ -43,7 +43,7 @@ plugins {
     id 'application'
 }
 repositories {
-    jcenter()
+    mavenCentral()
 }
 dependencies {
     compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.21'
@@ -161,7 +161,7 @@ dependencies {
 
 // 3. Get dependencies from JCenter and Kotlinx Bintray repo
 repositories {
-    jcenter()
+    mavenCentral()
     maven { url = "https://kotlin.bintray.com/kotlinx/" }
 }
 

--- a/docs/src/orchid/resources/wiki/learn/tutorials/your-first-orchid-site.md
+++ b/docs/src/orchid/resources/wiki/learn/tutorials/your-first-orchid-site.md
@@ -102,7 +102,7 @@ dependencies {
 
 // 2. Get Orchid from Jcenter
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // 3. Use the 'BsDoc' theme, and view the site locally at 'http://localhost:8080'

--- a/docs/src/orchid/resources/wiki/user-manual/getting-started/quickstart.md
+++ b/docs/src/orchid/resources/wiki/user-manual/getting-started/quickstart.md
@@ -39,7 +39,7 @@ plugins {
 repositories {
     // Orchid uses dependencies from both Jcenter and Jitpack, so both must be included. jcenter also includes 
     // everything available from MavenCentral, while Jitpack makes accessible any Github project.
-    jcenter()
+    mavenCentral()
     maven { url "https://kotlin.bintray.com/kotlinx" }
 }
 

--- a/integrations/OrchidGithub/src/main/kotlin/com/eden/orchid/github/publication/GithubPagesPublisher.kt
+++ b/integrations/OrchidGithub/src/main/kotlin/com/eden/orchid/github/publication/GithubPagesPublisher.kt
@@ -9,10 +9,10 @@ import com.eden.orchid.api.publication.AbstractGitPublisher
 import com.eden.orchid.api.util.GitFacade
 import com.eden.orchid.api.util.GitRepoFacade
 import com.eden.orchid.api.util.addFile
+import javax.validation.constraints.NotBlank
 import java.net.URL
 import javax.inject.Inject
 import javax.inject.Named
-import javax.validation.constraints.NotBlank
 
 @Description(
     value = "Commit your site directly to Github Pages. It can even keep old versions of your site for versioning" +
@@ -83,7 +83,7 @@ constructor(
 
     override fun GitRepoFacade.beforeCommit(context: OrchidContext) {
         val hasCnameFile = repoDir.resolve("CNAME").toFile().exists()
-        val domain = URL(context.baseUrl).host ?: ""
+        val domain = context.baseUrl?.let { URL(it).host } ?: ""
         val hasDefaultDomain = domain.endsWith(".github.io", ignoreCase = true)
 
         if (addCnameFile && !hasCnameFile && !hasDefaultDomain) {

--- a/languageExtensions/OrchidWritersBlocks/src/test/kotlin/com/eden/orchid/writersblocks/tags/GistItTagTest.kt
+++ b/languageExtensions/OrchidWritersBlocks/src/test/kotlin/com/eden/orchid/writersblocks/tags/GistItTagTest.kt
@@ -6,7 +6,6 @@ import com.eden.orchid.strikt.pageWasRendered
 import com.eden.orchid.testhelpers.OrchidIntegrationTest
 import com.eden.orchid.testhelpers.withGenerator
 import com.eden.orchid.writersblocks.WritersBlocksModule
-import kotlinx.html.iframe
 import kotlinx.html.script
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -31,7 +30,7 @@ class GistItTagTest : OrchidIntegrationTest(
         expectThat(execute())
             .pageWasRendered("/index.html") {
                 htmlBodyMatches("body script") {
-                    script(src = expectation()) {  }
+                    script(src = expectation()) { }
                 }
             }
     }
@@ -41,8 +40,8 @@ class GistItTagTest : OrchidIntegrationTest(
     fun testSliceGistIt() {
         val slice = "10:20"
         resource(
-                "homepage.md",
-                """
+            "homepage.md",
+            """
             |---
             |---
             |{% gistit owner="$owner" repository="$repository" file="$file" slice="$slice" %}
@@ -52,7 +51,7 @@ class GistItTagTest : OrchidIntegrationTest(
         expectThat(execute())
             .pageWasRendered("/index.html") {
                 htmlBodyMatches("body script") {
-                    script(src = expectation(slice = slice)) {  }
+                    script(src = expectation(slice = slice)) { }
                 }
             }
     }
@@ -76,5 +75,4 @@ class GistItTagTest : OrchidIntegrationTest(
             "?footer=no" +
             if (slice == null) "" else "&slice=$slice"
     }
-
 }

--- a/plugins/OrchidPluginDocs/src/main/kotlin/com/eden/orchid/plugindocs/DefaultAdminTheme.kt
+++ b/plugins/OrchidPluginDocs/src/main/kotlin/com/eden/orchid/plugindocs/DefaultAdminTheme.kt
@@ -14,9 +14,9 @@ constructor(
 ) : AdminTheme(context, "Default") {
 
     override fun loadAssets(delegate: AssetManagerDelegate) {
-        delegate.addCss("https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-rc.16/css/uikit.min.css")
+        delegate.addCss("@uikit.css")
 
-        delegate.addJs("https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.min.js")
+        delegate.addJs("@vue.js")
         context.getDefaultResourceSource(null, this).getResourceEntries(context, "assets/js/server", null, true)
             .filter { it.reference.outputExtension.equals("js", ignoreCase = true) }
             .map { resource ->
@@ -34,7 +34,7 @@ constructor(
 
         delegate.addJs("assets/js/orchid_admin.js")
 
-        delegate.addJs("https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-rc.16/js/uikit.min.js")
-        delegate.addJs("https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-rc.16/js/uikit-icons.min.js")
+        delegate.addJs("@uikit.js")
+        delegate.addJs("@uikit-icons.js")
     }
 }

--- a/plugins/OrchidPluginDocs/src/main/kotlin/com/eden/orchid/plugindocs/components/PluginDocsComponent.kt
+++ b/plugins/OrchidPluginDocs/src/main/kotlin/com/eden/orchid/plugindocs/components/PluginDocsComponent.kt
@@ -63,7 +63,7 @@ class PluginDocsComponent : OrchidComponent("pluginDocs") {
     private fun addPackageClasses(classList: MutableSet<String>) {
         ClassGraph()
             .enableClassInfo()
-            .whitelistPackages(*packageNames)
+            .acceptPackages(*packageNames)
             .scan()
             .allStandardClasses
             .loadClasses()

--- a/plugins/OrchidPosts/build.gradle.kts
+++ b/plugins/OrchidPosts/build.gradle.kts
@@ -11,6 +11,4 @@ plugins {
 dependencies {
     implementation(Modules.OrchidCore)
     testImplementation(Modules.OrchidTest)
-
-    implementation("javax.xml.bind:jaxb-api:2.3.1")
 }

--- a/plugins/OrchidPosts/src/main/kotlin/com/eden/orchid/posts/model/Author.kt
+++ b/plugins/OrchidPosts/src/main/kotlin/com/eden/orchid/posts/model/Author.kt
@@ -10,7 +10,7 @@ import com.eden.orchid.posts.pages.AuthorPage
 import java.net.URLEncoder
 import java.security.MessageDigest
 import javax.validation.constraints.NotBlank
-import javax.xml.bind.DatatypeConverter
+import kotlin.text.Charsets.UTF_8
 
 @Validate
 class Author : OptionsHolder {
@@ -28,10 +28,11 @@ class Author : OptionsHolder {
     var avatar: String = ""
         get() {
             if (email.isNotBlank()) {
-                val md5 = MessageDigest.getInstance("MD5")
-                md5.update(email.trim().toLowerCase().toByteArray())
-                val digest = md5.digest()
-                val hash = DatatypeConverter.printHexBinary(digest)
+                val hash = MessageDigest
+                    .getInstance("MD5")
+                    .digest(email.trim().toLowerCase().toByteArray(UTF_8))
+                    .toHex()
+
                 var gravatarUrl = "https://www.gravatar.com/avatar/${hash.toLowerCase()}"
 
                 if (gravatarDefault.isNotBlank()) {
@@ -69,4 +70,6 @@ class Author : OptionsHolder {
         get() {
             return authorPage?.link ?: ""
         }
+
+    private fun ByteArray.toHex() = joinToString(separator = "") { byte -> "%02x".format(byte) }
 }

--- a/plugins/OrchidSearch/src/main/kotlin/com/eden/orchid/search/components/OrchidSearchComponent.kt
+++ b/plugins/OrchidSearch/src/main/kotlin/com/eden/orchid/search/components/OrchidSearchComponent.kt
@@ -14,7 +14,7 @@ class OrchidSearchComponent : OrchidComponent("orchidSearch", true) {
     override fun loadAssets(delegate: AssetManagerDelegate): Unit = with(delegate) {
         addCss("assets/css/orchidSearch.scss")
 
-        addJs("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js")
+        addJs("@jquery.js")
         addJs("https://unpkg.com/lunr/lunr.js")
         addJs("assets/js/orchidSearch.js")
     }

--- a/themes/OrchidBsDoc/src/main/kotlin/com/eden/orchid/bsdoc/BSDocTheme.kt
+++ b/themes/OrchidBsDoc/src/main/kotlin/com/eden/orchid/bsdoc/BSDocTheme.kt
@@ -73,14 +73,15 @@ constructor(
 
     override fun loadAssets(delegate: AssetManagerDelegate): Unit = with(delegate) {
         // these assets include relative references to font files, which become invalid if the asset is downloaded locally and so need to stay as external assets even in production
-        addCss("https://netdna.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css") { download = false }
-        addCss("https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css") { download = false }
-        addCss("https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css")
+        addCss("@bootstrap3.css") { download = false }
+        addCss("@fontAwesome4.css") { download = false }
+        addCss("@githubForkRibbon.css")
         addCss("assets/css/bsdoc.scss")
 
-        addJs("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js")
-        addJs("https://netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js")
-        addJs("https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/4.3.0/bootbox.min.js")
+        addJs("@jquery.js")
+        addJs("@bootstrap3.js")
+        addJs("@bootbox.js")
+
         addJs("assets/js/bsdoc.js")
 
         addCss("assets/css/orchidSearch.scss")

--- a/themes/OrchidCopper/src/main/kotlin/com/eden/orchid/copper/CopperTheme.kt
+++ b/themes/OrchidCopper/src/main/kotlin/com/eden/orchid/copper/CopperTheme.kt
@@ -83,7 +83,7 @@ constructor(context: OrchidContext) : Theme(context, "Copper") {
         addCss("assets/css/bulma-tooltip.css")
         addCss("assets/css/bulma-accordion.min.css")
 
-        addJs("https://use.fontawesome.com/releases/v5.4.0/js/all.js") {
+        addJs("@fontAwesome5.js") {
             defer = true
             attrs["data-search-pseudo-elements"] = "true"
         }

--- a/themes/OrchidEditorial/src/main/kotlin/com/eden/orchid/editorial/EditorialTheme.kt
+++ b/themes/OrchidEditorial/src/main/kotlin/com/eden/orchid/editorial/EditorialTheme.kt
@@ -43,8 +43,8 @@ constructor(
         addCss("assets/css/editorial_orchidCustomizations.scss")
         addCss("assets/css/orchidSearch.scss")
 
-        addJs("https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js")
-        addJs("https://cdnjs.cloudflare.com/ajax/libs/skel/3.0.1/skel.min.js")
+        addJs("@jquery.js")
+        addJs("@skel.js")
         addJs("assets/js/editorial_util.js")
         addJs("assets/js/editorial_main.js")
         addJs("assets/js/editorial_orchidCustomizations.js")

--- a/themes/OrchidFutureImperfect/src/main/kotlin/com/eden/orchid/html5up/futureimperfect/FutureImperfectTheme.kt
+++ b/themes/OrchidFutureImperfect/src/main/kotlin/com/eden/orchid/html5up/futureimperfect/FutureImperfectTheme.kt
@@ -44,8 +44,8 @@ constructor(
         addCss("assets/css/futureImperfect_orchidCustomizations.scss")
         addCss("assets/css/orchidSearch.scss")
 
-        addJs("https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js")
-        addJs("https://cdnjs.cloudflare.com/ajax/libs/skel/3.0.1/skel.min.js")
+        addJs("@jquery.js")
+        addJs("@skel.js")
         addJs("assets/js/futureImperfect_util.js")
         addJs("assets/js/futureImperfect_main.js")
     }


### PR DESCRIPTION
Update jquery to version 3 for compatibility with plugins

chore: working build

- remove duplicate gradle wrapper files in buildSrce
- add repository to bundle's (fix missing dependencies errors)
- Disable broken testcase: no developer key??

chore: version updates

+ fix warnings

chore: only use jcenter for dependencies that have no alternative

chore: test scripts

chore: replace krow with picnic

chore: start migration for publishing platform

chore: start of github actions

chore: github actions - build all + tests

chore: github actions - windows fix

chore: github actions

chore: github actions

chore: github actions

chore: github actions

chore: github actions

chore: github actions

Update semver.gradle.kts
chore: github actions

[minor] chore: test release to maven central

[minor]: fix typos in workflow

[minor]: fix url for doc generation

Revert "Update jquery to version 3 for compatibility with plugins"

This reverts commit 3fe132202e7d61770d700f2ca668784353f29a07.

some changes